### PR TITLE
Adding 2 endpoints to get the schema

### DIFF
--- a/lib/controllers/app.js
+++ b/lib/controllers/app.js
@@ -16,6 +16,8 @@ module.exports = (req, res) => {
     resource.link('crud', RoutesInfo.expand('w2-app:crud'));
     resource.link('home', RoutesInfo.expand('w2-app:app', resource));
     resource.link('domain', RoutesInfo.expand('w2-app:domain', resource));
+    resource.link('schemaDomain', RoutesInfo.expand('w2-app:schema-domain', resource));
+    resource.link('schemaType', RoutesInfo.expand('w2-app:schema-type', resource));
 
     res.format({
         html: () => {

--- a/lib/controllers/domain.js
+++ b/lib/controllers/domain.js
@@ -1,34 +1,8 @@
 // const debug = require('debug')('W2:WarpJS:controllers:domain');
-const warpCore = require('@warp-works/core');
 const RoutesInfo = require('@quoin/expressjs-routes-info');
-
-const utils = require('./../utils');
 
 module.exports = (req, res) => {
     const domainName = req.params.domain;
-    /* TBD:
-    if (req.accepts("html")) {
-        const redirectURL = RoutesInfo.expand("w2-app:entity", { domain:domainName, type:domainName });
-        res.redirect(redirectURL);
-    }
-    else {
-    */
-        const resource = utils.createResource(req, {
-            domainName
-        });
-
-        try {
-            const domainJSN = warpCore.getDomainByName(domainName);
-            resource.domain = domainJSN.toJSON();
-            resource.success = true;
-        } catch (err) {
-            // TODO: Log this error?
-            resource.error = `Invalid domain name: '${domainName}'.`;
-            resource.success = false;
-        }
-
-        // TODO: Currently only sending back JSON. Could send back HTML if requested
-        // by wrapping inside of `res.format()`.
-        utils.sendHal(req, res, resource);
-    // }
+    const redirectURL = RoutesInfo.expand("w2-app:app", { domain: domainName, type: domainName });
+    res.redirect(redirectURL);
 };

--- a/lib/controllers/index.js
+++ b/lib/controllers/index.js
@@ -3,11 +3,13 @@ const crud = require('./crud');
 const domain = require('./domain');
 const domainList = require('./domain-list');
 const portal = require('./portal');
+const schema = require('./schema');
 
 module.exports = {
     app,
     crud,
     domain,
     domainList,
-    portal
+    portal,
+    schema
 };

--- a/lib/controllers/schema.js
+++ b/lib/controllers/schema.js
@@ -1,0 +1,50 @@
+const warpCore = require('@warp-works/core');
+
+const utils = require('./../utils');
+
+function domain(req, res) {
+    const domainName = req.params.domain;
+
+    const resource = utils.createResource(req, {
+        domainName
+    });
+
+    try {
+        const domainJSN = warpCore.getDomainByName(domainName);
+        resource.domain = domainJSN.toJSON();
+        resource.success = true;
+    } catch (err) {
+        // TODO: Log this error?
+        resource.error = `Invalid domain name: '${domainName}'.`;
+        resource.success = false;
+    }
+
+    utils.sendHal(req, res, resource);
+}
+
+function type(req, res) {
+    const domainName = req.params.domain;
+    const typeName = req.params.type;
+
+    const resource = utils.createResource(req, {
+        domainName,
+        typeName
+    });
+
+    try {
+        const domainJSN = warpCore.getDomainByName(domainName);
+        const typeJSN = domainJSN.getEntityByName(typeName);
+        resource.type = typeJSN.toJSON();
+        resource.success = true;
+    } catch (err) {
+        resource.error = `Invalid type name: '${domainName}/${typeName}'.`;
+        resource.success = false;
+    }
+
+    utils.sendHal(req, res, resource);
+}
+
+module.exports = {
+    domain,
+    type
+};

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -13,6 +13,12 @@ module.exports = (baseUrl) => {
     routesInfo.route('w2-app:domain', '/app/{domain}')
         .get(controllers.domain);
 
+    routesInfo.route('w2-app:schema-domain', '/app/schema/{domain}')
+        .get(controllers.schema.domain);
+
+    routesInfo.route('w2-app:schema-type', '/app/schema/{domain}/{type}')
+        .get(controllers.schema.type);
+
     routesInfo.route('w2-app:app', '/app/{domain}/{type}{?oid}')
         .get(controllers.app);
 


### PR DESCRIPTION
Create 2 new endpoints for getting domain schema and type schema.

The `/app/{domain}` endpoint is now just a redirect.