### PR TITLE
#29: Do not return deleted references

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 1.2.0-rc23 - 2017-11-22
+
+- Do not return the deleted references from the server.
+
 ## 1.2.0-rc22 - 2017-11-21
 
 - Fixed missing button to remove association.

--- a/lib/core/models/entity.js
+++ b/lib/core/models/entity.js
@@ -818,7 +818,10 @@ class Entity extends Base {
             const basicProperties = this.getBasicProperties()
                 .filter((basicProperty) => !basicProperty.isPassword())
                 .map((basicProperty) => basicProperty.name);
-            const data = docs.map((doc) => [
+
+            const existingDocs = docs.filter((doc) => doc.id && doc.type);
+
+            const data = existingDocs.map((doc) => [
                 RoutesInfo.expand('W2:content:instance', {
                     domain,
                     type: doc.type,
@@ -833,7 +836,7 @@ class Entity extends Base {
 
             resource.data = data;
 
-            const entities = docs.map((doc) => {
+            const entities = existingDocs.map((doc) => {
                 const resource = this.toResource(doc);
                 resource.docLevel = docLevel.concat(`Entity:${doc.id}`).join('.');
                 return resource;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warp-works/warpjs",
-  "version": "1.2.0-rc22",
+  "version": "1.2.0-rc23",
   "description": "Content management system for WarpWorks in javascript",
   "repository": {
     "type": "git",

--- a/server/portal/instance/page/extract-page-view.js
+++ b/server/portal/instance/page/extract-page-view.js
@@ -37,7 +37,8 @@ function extractRelationship(req, resource, persistence, hsEntity, entity) {
     return Promise.resolve()
         .then(() => relationship.getDocuments(persistence, entity))
         .then((references) => {
-            return Promise.map(references, (reference) => {
+            const onlyExistingReferences = references.filter((reference) => reference.id && reference.type);
+            return Promise.map(onlyExistingReferences, (reference) => {
                 const referenceResource = createObjResource(reference, true);
                 if (hsEntity.style === 'Preview') {
                     const referenceEntity = hsEntity.getRelationship().getTargetEntity();


### PR DESCRIPTION
The server nows doesn't send back the deleted reference for the portal page and the basic property on the content (for the association modal).

Closes #29 